### PR TITLE
prepare for shinydashboardPlus 2.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     plotly,
     tippy,
     shinyWidgets,
-    shinydashboardPlus,
+    shinydashboardPlus (>= 2.0.0),
     shinydashboard,
     rlang,
     shiny.i18n

--- a/R/distributionPlotBoxCopulas.R
+++ b/R/distributionPlotBoxCopulas.R
@@ -191,7 +191,7 @@ distributionPlotBoxCopulas <- function(input, output, session, copula) { #, lang
 #'  function. Should not be run directly.
 #'
 #' @importFrom shiny NS uiOutput
-#' @importFrom shinydashboardPlus boxPlus
+#' @importFrom shinydashboardPlus box
 #' @importFrom tippy tippyOutput
 #' @importFrom plotly plotlyOutput
 #' @export
@@ -201,7 +201,7 @@ distributionPlotBoxCopulas <- function(input, output, session, copula) { #, lang
 distributionPlotBoxCopulasUI <- function(id) {
     ns <- shiny::NS(id)
 
-    shinydashboardPlus::boxPlus(
+    shinydashboardPlus::box(
         # title = shiny::textOutput(ns("distributionPlotTitle")),
         title = "Plot",
         width = NULL,

--- a/R/functionsBox.R
+++ b/R/functionsBox.R
@@ -264,7 +264,7 @@ functionsBox <- function(input, output, session, law) { #, lang
 #'  Should not be run directly.
 #'
 #' @importFrom shiny NS uiOutput
-#' @importFrom shinydashboardPlus boxPlus
+#' @importFrom shinydashboardPlus box
 #' @importFrom tippy tippyOutput
 #' @importFrom plotly plotlyOutput
 #' @export
@@ -274,7 +274,7 @@ functionsBox <- function(input, output, session, law) { #, lang
 functionsBoxUI <- function(id) {
     ns <- shiny::NS(id)
 
-    shinydashboardPlus::boxPlus(
+    shinydashboardPlus::box(
         # title = shiny::textOutput(ns("functionsTitle")),
         title = "Functions",
         width = NULL,

--- a/R/parametersBox.R
+++ b/R/parametersBox.R
@@ -81,7 +81,7 @@ parametersBox <- function(input, output, session, law) {# , lang
 #'  Should not be run directly.
 #'
 #' @importFrom shiny NS uiOutput textOutput
-#' @importFrom shinydashboardPlus boxPlus
+#' @importFrom shinydashboardPlus box
 #' @export
 #'
 #' @keywords internal
@@ -90,7 +90,7 @@ parametersBoxUI <- function(id) {
     ns <- shiny::NS(id)
 
     #### Parameters ####
-    shinydashboardPlus::boxPlus(
+    shinydashboardPlus::box(
         # title = shiny::textOutput(ns("parametersTitle")),
         title = 'Parameters',
         status = "primary",

--- a/R/parametersBoxCopulas.R
+++ b/R/parametersBoxCopulas.R
@@ -75,7 +75,7 @@ parametersBoxCopulas <- function(input, output, session, copula) { #, lang
 #'  function. Should not be run directly.
 #'
 #' @importFrom shiny NS uiOutput textOutput
-#' @importFrom shinydashboardPlus boxPlus
+#' @importFrom shinydashboardPlus box
 #' @export
 #'
 #' @keywords internal
@@ -85,7 +85,7 @@ parametersBoxCopulasUI <- function(id) {
     ns <- shiny::NS(id)
 
     #### Parameters ####
-    shinydashboardPlus::boxPlus(
+    shinydashboardPlus::box(
         # title = shiny::textOutput(ns("parametersTitle")),
         title = "Parameters",
         status = "info",

--- a/R/riskMeasuresBox.R
+++ b/R/riskMeasuresBox.R
@@ -242,7 +242,7 @@ riskMeasuresBox <- function(input, output, session, law) { #, lang
 #'  Should not be run directly.
 #'
 #' @importFrom shiny tags NS uiOutput
-#' @importFrom shinydashboardPlus boxPlus
+#' @importFrom shinydashboardPlus box
 #' @importFrom tippy tippyOutput
 #' @importFrom plotly plotlyOutput
 #' @export
@@ -252,7 +252,7 @@ riskMeasuresBox <- function(input, output, session, law) { #, lang
 riskMeasuresBoxUI <- function(id) {
     ns <- shiny::NS(id)
 
-    shinydashboardPlus::boxPlus(
+    shinydashboardPlus::box(
         # title = shiny::textOutput(ns("riskMeasuresTitle")),
         title = "Risk measures",
         width = NULL,

--- a/R/simulationsPlotBoxCopulas.R
+++ b/R/simulationsPlotBoxCopulas.R
@@ -84,7 +84,7 @@ simulationsPlotBoxCopulas <- function(input, output, session, copula, lang) {
 #'  function. Should not be run directly.
 #'
 #' @importFrom shiny NS uiOutput
-#' @importFrom shinydashboardPlus boxPlus
+#' @importFrom shinydashboardPlus box
 #' @importFrom tippy tippyOutput
 #' @importFrom plotly plotlyOutput
 #' @export
@@ -94,7 +94,7 @@ simulationsPlotBoxCopulas <- function(input, output, session, copula, lang) {
 simulationsPlotBoxCopulasUI <- function(id) {
     ns <- shiny::NS(id)
 
-    shinydashboardPlus::boxPlus(
+    shinydashboardPlus::box(
         title = shiny::textOutput(ns("simulationsPlotTitle")),
         width = NULL,
         solidHeader = TRUE,


### PR DESCRIPTION
Received a mail from CRAN since shinydashboardPlus is breaking due to a breaking change in the shinyjqui dependency. v2.0.0 is causing some issues in your package. Here is a patch to fix them ;)

Only merge as soon as shinydashboardPlus 2.0.0 reaches the CRAN, not before. 

Best 

David